### PR TITLE
Suggest to define /notebooks as workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,6 @@ RUN ls -la /notebooks/courses/dl1/data/
 
 RUN chmod -R a+w /notebooks
 
+WORKDIR /notebooks
+
 CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--no-browser", "--allow-root"]


### PR DESCRIPTION
Seems to be better as a root dir for jupyter